### PR TITLE
WIP: personality layering snapshot

### DIFF
--- a/crates/sieve-app/src/agent_loop.rs
+++ b/crates/sieve-app/src/agent_loop.rs
@@ -44,6 +44,7 @@ pub(crate) async fn run_agent_loop(
         let cfg = cfg.clone();
         let telegram_tx = telegram_tx.clone();
         let source = prompt.source;
+        let destination = prompt.destination;
         let text = prompt.text;
         let modality = prompt.modality;
         let media_file_id = prompt.media_file_id;
@@ -68,6 +69,7 @@ pub(crate) async fn run_agent_loop(
                 &cfg,
                 run_index,
                 source,
+                destination,
                 modality,
                 media_file_id,
                 text,

--- a/crates/sieve-app/src/compose.rs
+++ b/crates/sieve-app/src/compose.rs
@@ -272,7 +272,9 @@ pub(crate) async fn compose_assistant_message(
     let payload = serde_json::json!({
         "task": "compose_user_reply",
         "trusted_user_message": trusted_user_message,
+        "delivery_context": response_input.delivery_context.clone(),
         "response_modality": response_input.response_modality,
+        "resolved_personality": response_input.resolved_personality.clone(),
         "user_requested_sources": user_requested_sources(trusted_user_message),
         "user_requested_detailed_output": user_requested_detailed_output(trusted_user_message),
         "trusted_evidence": trusted_evidence.clone(),
@@ -316,8 +318,7 @@ pub(crate) async fn compose_assistant_message(
     )
     .await;
     let mut retry_diagnostics = Vec::new();
-    if let Some(diagnostic) =
-        compose_gate_requires_retry(&composed, trusted_user_message, gate.as_ref())
+    if let Some(diagnostic) = compose_gate_requires_retry(&composed, response_input, gate.as_ref())
     {
         retry_diagnostics.push(diagnostic);
     }
@@ -327,7 +328,9 @@ pub(crate) async fn compose_assistant_message(
         let retry_payload = serde_json::json!({
             "task": "compose_user_reply",
             "trusted_user_message": trusted_user_message,
+            "delivery_context": response_input.delivery_context.clone(),
             "response_modality": response_input.response_modality,
+            "resolved_personality": response_input.resolved_personality.clone(),
             "user_requested_sources": user_requested_sources(trusted_user_message),
             "user_requested_detailed_output": user_requested_detailed_output(trusted_user_message),
             "trusted_evidence": trusted_evidence.clone(),

--- a/crates/sieve-app/src/compose_gate.rs
+++ b/crates/sieve-app/src/compose_gate.rs
@@ -292,7 +292,7 @@ pub(crate) fn parse_compose_gate_output(raw: Option<&str>) -> Option<ComposeGate
 
 pub(crate) fn compose_gate_requires_retry(
     composed_message: &str,
-    trusted_user_message: &str,
+    response_input: &ResponseTurnInput,
     gate: Option<&ComposeGateOutput>,
 ) -> Option<String> {
     if obvious_meta_compose_pattern(composed_message) {
@@ -300,7 +300,11 @@ pub(crate) fn compose_gate_requires_retry(
             "response used third-person meta narration; respond directly to user".to_string(),
         );
     }
-    if let Some(diagnostic) = concise_style_diagnostic(composed_message, trusted_user_message) {
+    if let Some(diagnostic) = concise_style_diagnostic(
+        composed_message,
+        &response_input.trusted_user_message,
+        response_input.resolved_personality.verbosity,
+    ) {
         return Some(diagnostic);
     }
     let gate = gate?;

--- a/crates/sieve-app/src/ingress.rs
+++ b/crates/sieve-app/src/ingress.rs
@@ -31,6 +31,7 @@ impl PromptSource {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct IngressPrompt {
     pub(crate) source: PromptSource,
+    pub(crate) destination: Option<String>,
     pub(crate) text: String,
     pub(crate) modality: InteractionModality,
     pub(crate) media_file_id: Option<String>,
@@ -80,6 +81,7 @@ impl TelegramEventBridge for RuntimeBridge {
         if let Some(prompt_tx) = &self.prompt_tx {
             if let Err(err) = prompt_tx.send(IngressPrompt {
                 source: PromptSource::Telegram,
+                destination: Some(prompt.chat_id.to_string()),
                 text,
                 modality: prompt.modality,
                 media_file_id: prompt.media_file_id,
@@ -167,6 +169,7 @@ pub(crate) fn spawn_stdin_prompt_loop(
                     }
                     if let Err(err) = prompt_tx.send(IngressPrompt {
                         source: PromptSource::Stdin,
+                        destination: None,
                         text: prompt.to_string(),
                         modality: InteractionModality::Text,
                         media_file_id: None,

--- a/crates/sieve-app/src/main.rs
+++ b/crates/sieve-app/src/main.rs
@@ -8,6 +8,7 @@ mod ingress;
 mod lcm_integration;
 mod logging;
 mod media;
+mod personality;
 mod planner_feedback;
 mod planner_progress;
 mod render_refs;
@@ -49,6 +50,9 @@ use logging::FanoutRuntimeEventLog;
 pub(crate) use logging::{
     append_jsonl_record, now_ms, ConversationLogRecord, ConversationRole, TelegramLoopEvent,
 };
+#[cfg(test)]
+#[allow(unused_imports)]
+pub(crate) use personality::{personality_state_path, resolve_turn_personality};
 #[cfg(test)]
 #[allow(unused_imports)]
 pub(crate) use planner_feedback::{planner_memory_feedback, planner_policy_feedback};
@@ -238,6 +242,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             &cfg,
             1,
             PromptSource::Stdin,
+            None,
             InteractionModality::Text,
             None,
             cli_prompt,

--- a/crates/sieve-app/src/personality.rs
+++ b/crates/sieve-app/src/personality.rs
@@ -1,0 +1,633 @@
+use crate::ingress::PromptSource;
+use sieve_types::{
+    DeliveryChannel, DeliveryContext, EmojiPolicy, InteractionModality, PersonalitySettings,
+    ResolvedPersonality, ResponseVerbosity,
+};
+use std::collections::BTreeSet;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+const PERSONALITY_SCHEMA_VERSION: u16 = 1;
+const DEFAULT_IDENTITY: &str = "helpful, optimistic, cheerful personal assistant";
+const DEFAULT_STYLE: &str = "clear and concise";
+static PERSONALITY_TMP_NONCE: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+struct PersonalityStateFile {
+    schema_version: u16,
+    #[serde(default)]
+    settings: PersonalitySettings,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PersonalityDirective {
+    settings: PersonalitySettings,
+    persist: bool,
+    style_only: bool,
+    reset: bool,
+    acknowledgement: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PersonalityTurnResolution {
+    pub(crate) delivery_context: DeliveryContext,
+    pub(crate) resolved_personality: ResolvedPersonality,
+    pub(crate) acknowledgement: Option<String>,
+}
+
+pub(crate) fn personality_state_path(sieve_home: &Path) -> PathBuf {
+    sieve_home.join("state/personality.json")
+}
+
+pub(crate) fn resolve_turn_personality(
+    sieve_home: &Path,
+    source: PromptSource,
+    destination: Option<&str>,
+    input_modality: InteractionModality,
+    response_modality: InteractionModality,
+    trusted_user_message: &str,
+) -> Result<PersonalityTurnResolution, String> {
+    let delivery_context = DeliveryContext {
+        channel: delivery_channel_for_source(source),
+        destination: destination.map(str::to_string),
+        input_modality,
+        response_modality,
+    };
+
+    let path = personality_state_path(sieve_home);
+    let mut persisted = load_personality_settings(&path)?;
+    let directive = parse_personality_directive(trusted_user_message);
+    let turn_settings = if let Some(directive) = directive.as_ref() {
+        if directive.reset {
+            persisted = PersonalitySettings::default();
+        } else if directive.persist {
+            persisted = merge_settings(&persisted, &directive.settings);
+        }
+        if directive.persist || directive.reset {
+            save_personality_settings(&path, &persisted)?;
+        }
+        directive.settings.clone()
+    } else {
+        PersonalitySettings::default()
+    };
+    let effective_turn_settings = if directive
+        .as_ref()
+        .map(|value| value.persist)
+        .unwrap_or(false)
+    {
+        PersonalitySettings::default()
+    } else {
+        turn_settings.clone()
+    };
+
+    Ok(PersonalityTurnResolution {
+        delivery_context: delivery_context.clone(),
+        resolved_personality: resolve_personality(
+            &delivery_context,
+            &persisted,
+            &effective_turn_settings,
+        ),
+        acknowledgement: directive
+            .as_ref()
+            .filter(|value| value.style_only)
+            .map(|value| value.acknowledgement.clone()),
+    })
+}
+
+fn delivery_channel_for_source(source: PromptSource) -> DeliveryChannel {
+    match source {
+        PromptSource::Stdin => DeliveryChannel::Stdin,
+        PromptSource::Telegram => DeliveryChannel::Telegram,
+    }
+}
+
+fn load_personality_settings(path: &Path) -> Result<PersonalitySettings, String> {
+    let body = match fs::read_to_string(path) {
+        Ok(body) => body,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            return Ok(PersonalitySettings::default())
+        }
+        Err(err) => return Err(format!("failed reading {}: {err}", path.display())),
+    };
+    let parsed: PersonalityStateFile = serde_json::from_str(&body)
+        .map_err(|err| format!("failed parsing {}: {err}", path.display()))?;
+    if parsed.schema_version != PERSONALITY_SCHEMA_VERSION {
+        return Err(format!(
+            "unsupported personality schema_version {} in {}",
+            parsed.schema_version,
+            path.display()
+        ));
+    }
+    Ok(parsed.settings)
+}
+
+fn save_personality_settings(path: &Path, settings: &PersonalitySettings) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|err| format!("failed creating {}: {err}", parent.display()))?;
+    }
+    let payload = PersonalityStateFile {
+        schema_version: PERSONALITY_SCHEMA_VERSION,
+        settings: settings.clone(),
+    };
+    let encoded = serde_json::to_string_pretty(&payload)
+        .map_err(|err| format!("failed encoding personality state: {err}"))?;
+    let nonce = PERSONALITY_TMP_NONCE.fetch_add(1, Ordering::Relaxed);
+    let tmp_path = path.with_extension(format!("json.tmp.{}.{}", std::process::id(), nonce));
+    fs::write(&tmp_path, encoded)
+        .map_err(|err| format!("failed writing {}: {err}", tmp_path.display()))?;
+    fs::rename(&tmp_path, path).map_err(|err| {
+        format!(
+            "failed renaming {} to {}: {err}",
+            tmp_path.display(),
+            path.display()
+        )
+    })
+}
+
+fn resolve_personality(
+    delivery_context: &DeliveryContext,
+    persisted: &PersonalitySettings,
+    turn: &PersonalitySettings,
+) -> ResolvedPersonality {
+    let mut resolved = ResolvedPersonality {
+        identity: DEFAULT_IDENTITY.to_string(),
+        style: DEFAULT_STYLE.to_string(),
+        emoji_policy: turn
+            .emoji_policy
+            .or(persisted.emoji_policy)
+            .unwrap_or_else(|| default_emoji_policy(delivery_context)),
+        verbosity: turn
+            .verbosity
+            .or(persisted.verbosity)
+            .unwrap_or_else(|| default_verbosity(delivery_context)),
+        channel_guidance: channel_guidance(delivery_context),
+        custom_instructions: dedupe_preserve_order(
+            persisted
+                .custom_instructions
+                .iter()
+                .chain(turn.custom_instructions.iter())
+                .cloned()
+                .collect(),
+        ),
+    };
+    if delivery_context.response_modality == InteractionModality::Audio {
+        resolved.emoji_policy = EmojiPolicy::Avoid;
+    }
+    resolved
+}
+
+fn default_emoji_policy(delivery_context: &DeliveryContext) -> EmojiPolicy {
+    if delivery_context.response_modality == InteractionModality::Audio {
+        return EmojiPolicy::Avoid;
+    }
+    match delivery_context.channel {
+        DeliveryChannel::Telegram => EmojiPolicy::Light,
+        DeliveryChannel::Stdin => EmojiPolicy::Avoid,
+    }
+}
+
+fn default_verbosity(delivery_context: &DeliveryContext) -> ResponseVerbosity {
+    match delivery_context.channel {
+        DeliveryChannel::Telegram => ResponseVerbosity::Concise,
+        DeliveryChannel::Stdin => ResponseVerbosity::Concise,
+    }
+}
+
+fn channel_guidance(delivery_context: &DeliveryContext) -> Vec<String> {
+    let mut guidance = match delivery_context.channel {
+        DeliveryChannel::Telegram => vec![
+            "Write in short chat-sized paragraphs suited to Telegram.".to_string(),
+            "Keep the tone warm and direct, not essay-like.".to_string(),
+        ],
+        DeliveryChannel::Stdin => vec![
+            "Use plain text that reads well in a terminal.".to_string(),
+            "Prefer direct, compact wording over chatty filler.".to_string(),
+        ],
+    };
+    match delivery_context.response_modality {
+        InteractionModality::Audio => guidance.push(
+            "Write as spoken audio: natural cadence, contractions, and no markdown-dependent phrasing."
+                .to_string(),
+        ),
+        InteractionModality::Image => guidance.push(
+            "If discussing an image result, keep wording concise and descriptive.".to_string(),
+        ),
+        InteractionModality::Text => {}
+    }
+    guidance
+}
+
+fn merge_settings(
+    base: &PersonalitySettings,
+    overlay: &PersonalitySettings,
+) -> PersonalitySettings {
+    PersonalitySettings {
+        emoji_policy: overlay.emoji_policy.or(base.emoji_policy),
+        verbosity: overlay.verbosity.or(base.verbosity),
+        custom_instructions: if overlay.custom_instructions.is_empty() {
+            base.custom_instructions.clone()
+        } else {
+            dedupe_preserve_order(overlay.custom_instructions.clone())
+        },
+    }
+}
+
+fn parse_personality_directive(trusted_user_message: &str) -> Option<PersonalityDirective> {
+    let normalized = trusted_user_message.trim();
+    if normalized.is_empty() {
+        return None;
+    }
+    let lower = normalized.to_ascii_lowercase();
+    if !contains_style_request(&lower) {
+        return None;
+    }
+
+    let reset = contains_any(
+        &lower,
+        &[
+            "reset personality",
+            "reset your personality",
+            "use the default style",
+            "use the default personality",
+            "back to normal",
+            "normal style",
+            "default style again",
+        ],
+    );
+    let style_only = is_style_only_request(&lower);
+    let persist = if contains_any(
+        &lower,
+        &[
+            "for this reply",
+            "for this response",
+            "for this message",
+            "this time",
+            "for now",
+            "right now",
+        ],
+    ) {
+        false
+    } else if contains_any(
+        &lower,
+        &[
+            "from now on",
+            "going forward",
+            "by default",
+            "default to",
+            "every reply",
+            "every response",
+            "in general",
+            "always",
+        ],
+    ) {
+        true
+    } else {
+        style_only
+    };
+
+    let mut settings = PersonalitySettings::default();
+    if contains_any(
+        &lower,
+        &[
+            "a lot of emoji",
+            "a lot of emojis",
+            "lots of emoji",
+            "lots of emojis",
+            "many emojis",
+            "multiple emojis",
+            "2+ emoji",
+            "2+ emojis",
+            "emoji heavy",
+            "emoji-heavy",
+        ],
+    ) {
+        settings.emoji_policy = Some(EmojiPolicy::Auto);
+        settings.custom_instructions.push(
+            "Use an emoji-heavy chat style with multiple emojis in text replies.".to_string(),
+        );
+    } else if contains_any(
+        &lower,
+        &[
+            "don't use emoji",
+            "dont use emoji",
+            "don't use emojis",
+            "dont use emojis",
+            "no emoji",
+            "no emojis",
+            "without emoji",
+            "without emojis",
+            "skip emoji",
+            "skip emojis",
+        ],
+    ) {
+        settings.emoji_policy = Some(EmojiPolicy::Avoid);
+    } else if contains_any(
+        &lower,
+        &[
+            "use emoji",
+            "use emojis",
+            "using emoji",
+            "using emojis",
+            "start using emoji",
+            "start using emojis",
+            "with emoji",
+            "with emojis",
+            "more emoji",
+            "more emojis",
+        ],
+    ) {
+        settings.emoji_policy = Some(EmojiPolicy::Light);
+    }
+
+    if contains_any(
+        &lower,
+        &["telegraph", "telegram style telegraph", "conserve tokens"],
+    ) {
+        settings.verbosity = Some(ResponseVerbosity::Telegraph);
+    } else if contains_any(
+        &lower,
+        &[
+            "more terse",
+            "terser",
+            "brief",
+            "concise",
+            "shorter",
+            "keep it short",
+            "short replies",
+        ],
+    ) {
+        settings.verbosity = Some(ResponseVerbosity::Concise);
+    } else if contains_any(
+        &lower,
+        &[
+            "more detailed",
+            "be detailed",
+            "more detail",
+            "detailed",
+            "longer",
+            "more verbose",
+            "thorough",
+        ],
+    ) {
+        settings.verbosity = Some(ResponseVerbosity::Detailed);
+    }
+
+    if let Some(instruction) = tone_instruction(&lower) {
+        settings.custom_instructions.push(instruction.to_string());
+    } else if let Some(instruction) = persona_instruction(normalized, &lower) {
+        settings.custom_instructions.push(instruction);
+    } else if contains_any(
+        &lower,
+        &[
+            "pretend",
+            "act like",
+            "acting like",
+            "behave more",
+            "sound more",
+            "speak more",
+            "talk like",
+            "write like",
+            "you are my",
+        ],
+    ) && settings.verbosity.is_none()
+    {
+        settings
+            .custom_instructions
+            .push(compact_instruction(normalized, 220));
+    }
+
+    if !reset
+        && settings.emoji_policy.is_none()
+        && settings.verbosity.is_none()
+        && settings.custom_instructions.is_empty()
+    {
+        return None;
+    }
+
+    Some(PersonalityDirective {
+        acknowledgement: build_acknowledgement(reset, persist, &settings),
+        settings,
+        persist,
+        style_only,
+        reset,
+    })
+}
+
+fn build_acknowledgement(reset: bool, persist: bool, settings: &PersonalitySettings) -> String {
+    if reset {
+        return "I'll use the default assistant style again.".to_string();
+    }
+
+    let mut parts = Vec::new();
+    match settings.verbosity {
+        Some(ResponseVerbosity::Concise) => parts.push("keep replies concise".to_string()),
+        Some(ResponseVerbosity::Detailed) => {
+            parts.push("allow more detail when it helps".to_string())
+        }
+        Some(ResponseVerbosity::Telegraph) => {
+            parts.push("use terse, telegraph-style phrasing".to_string())
+        }
+        None => {}
+    }
+    match settings.emoji_policy {
+        Some(EmojiPolicy::Avoid) => parts.push("skip emojis".to_string()),
+        Some(EmojiPolicy::Light) => parts.push("use light emojis when they fit".to_string()),
+        Some(EmojiPolicy::Auto) => parts.push("lean into emojis".to_string()),
+        None => {}
+    }
+    for note in settings.custom_instructions.iter().take(2) {
+        parts.push(compact_instruction(note.trim_end_matches('.'), 80).to_ascii_lowercase());
+    }
+    if parts.is_empty() {
+        parts.push("adjust the tone".to_string());
+    }
+
+    let joined = join_with_and(&parts);
+    if persist {
+        format!("I'll {joined} from now on.")
+    } else {
+        format!("For this reply, I'll {joined}.")
+    }
+}
+
+fn contains_style_request(lower: &str) -> bool {
+    contains_any(
+        lower,
+        &[
+            "emoji",
+            "emojis",
+            "tone",
+            "personality",
+            "style",
+            "reply",
+            "replies",
+            "respond",
+            "response",
+            "responses",
+            "speak",
+            "sound",
+            "behave",
+            "pretend",
+            "act like",
+            "acting like",
+            "talk like",
+            "write like",
+            "flirty",
+            "formal",
+            "casual",
+            "friendly",
+            "serious",
+            "playful",
+            "cheerful",
+            "optimistic",
+            "terse",
+            "concise",
+            "detailed",
+            "telegraph",
+        ],
+    )
+}
+
+fn is_style_only_request(lower: &str) -> bool {
+    contains_style_request(lower)
+        && !contains_any(
+            lower,
+            &[
+                "what ",
+                "when ",
+                "where ",
+                "who ",
+                "why ",
+                "how ",
+                "find ",
+                "look up",
+                "search ",
+                "tell me",
+                "show me",
+                "summarize",
+                "summary",
+                "draft ",
+                "write ",
+                "run ",
+                "execute ",
+                "weather",
+                "latest",
+                "status",
+                "explain ",
+                "list ",
+            ],
+        )
+}
+
+fn tone_instruction(lower: &str) -> Option<&'static str> {
+    if lower.contains("flirty") || lower.contains("sexy secretary") {
+        Some("Use a flirtier, playful tone.")
+    } else if lower.contains("formal") {
+        Some("Use a more formal tone.")
+    } else if lower.contains("casual") {
+        Some("Use a more casual tone.")
+    } else if lower.contains("friendly") {
+        Some("Keep the tone friendly.")
+    } else if lower.contains("playful") {
+        Some("Keep the tone playful.")
+    } else if lower.contains("serious") {
+        Some("Keep the tone serious.")
+    } else if lower.contains("cheerful") {
+        Some("Keep the tone cheerful.")
+    } else if lower.contains("optimistic") {
+        Some("Keep the tone optimistic.")
+    } else {
+        None
+    }
+}
+
+fn persona_instruction(normalized: &str, lower: &str) -> Option<String> {
+    for marker in [
+        "acting like ",
+        "act like ",
+        "sound like ",
+        "speak like ",
+        "talk like ",
+        "write like ",
+        "behave like ",
+        "you are my ",
+    ] {
+        let Some(start) = lower.find(marker) else {
+            continue;
+        };
+        let phrase = normalized[start + marker.len()..]
+            .trim()
+            .trim_matches(|ch: char| matches!(ch, '.' | ',' | ';' | ':' | '!' | '?'));
+        if phrase.is_empty() {
+            continue;
+        }
+        let phrase = compact_instruction(phrase, 60);
+        let article_prefix = if phrase.starts_with("a ")
+            || phrase.starts_with("an ")
+            || phrase.starts_with("the ")
+        {
+            ""
+        } else {
+            "a "
+        };
+        return Some(format!("Adopt {article_prefix}{phrase} persona."));
+    }
+    None
+}
+
+fn dedupe_preserve_order(values: Vec<String>) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    let mut out = Vec::new();
+    for value in values {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if seen.insert(trimmed.to_string()) {
+            out.push(trimmed.to_string());
+        }
+    }
+    out
+}
+
+fn compact_instruction(input: &str, max_len: usize) -> String {
+    let compact = input.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.chars().count() <= max_len {
+        return compact;
+    }
+    let mut out = String::new();
+    for ch in compact.chars().take(max_len.saturating_sub(3)) {
+        out.push(ch);
+    }
+    out.push_str("...");
+    out
+}
+
+fn contains_any(haystack: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| haystack.contains(needle))
+}
+
+fn join_with_and(parts: &[String]) -> String {
+    match parts {
+        [] => "adjust the tone".to_string(),
+        [only] => only.clone(),
+        [first, second] => format!("{first} and {second}"),
+        _ => {
+            let mut out = String::new();
+            for (idx, part) in parts.iter().enumerate() {
+                if idx > 0 {
+                    if idx + 1 == parts.len() {
+                        out.push_str(", and ");
+                    } else {
+                        out.push_str(", ");
+                    }
+                }
+                out.push_str(part);
+            }
+            out
+        }
+    }
+}

--- a/crates/sieve-app/src/response_style.rs
+++ b/crates/sieve-app/src/response_style.rs
@@ -1,5 +1,6 @@
 use crate::planner_progress::url_is_likely_asset;
 use sieve_llm::ResponseTurnInput;
+use sieve_types::ResponseVerbosity;
 use std::collections::BTreeSet;
 
 pub(crate) fn dedupe_preserve_order(values: Vec<String>) -> Vec<String> {
@@ -234,17 +235,24 @@ fn sentence_like_count(message: &str) -> usize {
 pub(crate) fn concise_style_diagnostic(
     composed_message: &str,
     trusted_user_message: &str,
+    verbosity: ResponseVerbosity,
 ) -> Option<String> {
-    if user_requested_detailed_output(trusted_user_message) {
+    if user_requested_detailed_output(trusted_user_message)
+        || verbosity == ResponseVerbosity::Detailed
+    {
         return None;
     }
     let sentence_count = sentence_like_count(composed_message);
     let char_count = composed_message.chars().count();
-    if sentence_count > 4 || char_count > 650 {
-        return Some(
-            "response is too long; keep to 1-2 concise sentences unless user asks for detail"
-                .to_string(),
-        );
+    let (sentence_limit, char_limit, label) = match verbosity {
+        ResponseVerbosity::Telegraph => (2, 240, "response is too long for telegraph style"),
+        ResponseVerbosity::Detailed => (usize::MAX, usize::MAX, ""),
+        ResponseVerbosity::Concise => (4, 650, "response is too long"),
+    };
+    if sentence_count > sentence_limit || char_count > char_limit {
+        return Some(format!(
+            "{label}; keep to 1-2 concise sentences unless user asks for detail"
+        ));
     }
     let url_count = extract_plain_urls_from_text(composed_message).len();
     if url_count > 1 && !user_requested_sources(trusted_user_message) {
@@ -331,16 +339,35 @@ pub(crate) fn denied_outcomes_only_message(response_input: &ResponseTurnInput) -
         return None;
     }
 
-    let mut message = details
-        .iter()
-        .take(2)
-        .map(|(command, reason)| format!("I tried `{command}`, but it was blocked: {reason}."))
-        .collect::<Vec<_>>()
-        .join(" ");
+    let mut message = if response_input.resolved_personality.verbosity
+        == ResponseVerbosity::Telegraph
+    {
+        details
+            .iter()
+            .take(2)
+            .map(|(command, reason)| format!("Tried `{command}`; blocked: {reason}."))
+            .collect::<Vec<_>>()
+            .join(" ")
+    } else {
+        details
+            .iter()
+            .take(2)
+            .map(|(command, reason)| format!("I tried `{command}`, but it was blocked: {reason}."))
+            .collect::<Vec<_>>()
+            .join(" ")
+    };
     if details.len() > 2 {
-        message.push_str(" I hit the same restriction on additional attempts.");
+        if response_input.resolved_personality.verbosity == ResponseVerbosity::Telegraph {
+            message.push_str(" Same issue on additional attempts.");
+        } else {
+            message.push_str(" I hit the same restriction on additional attempts.");
+        }
     }
-    message.push_str(" I can try a different command path if you want.");
+    if response_input.resolved_personality.verbosity == ResponseVerbosity::Telegraph {
+        message.push_str(" I can try another path.");
+    } else {
+        message.push_str(" I can try a different command path if you want.");
+    }
     Some(message)
 }
 

--- a/crates/sieve-app/src/tests.rs
+++ b/crates/sieve-app/src/tests.rs
@@ -28,6 +28,7 @@ mod e2e_live;
 mod guidance_progress;
 mod media;
 mod models;
+mod personality;
 mod planner_core;
 mod render_response;
 mod response_style;

--- a/crates/sieve-app/src/tests/compose_feedback.rs
+++ b/crates/sieve-app/src/tests/compose_feedback.rs
@@ -4,7 +4,12 @@ fn compose_quality_followup_only_triggers_for_missing_evidence() {
     let with_refs = ResponseTurnInput {
         run_id: RunId("run-1".to_string()),
         trusted_user_message: "weather".to_string(),
+        delivery_context: test_delivery_context(
+            sieve_types::DeliveryChannel::Stdin,
+            InteractionModality::Text,
+        ),
         response_modality: InteractionModality::Text,
+        resolved_personality: test_resolved_personality(),
         planner_thoughts: None,
         tool_outcomes: vec![ResponseToolOutcome {
             tool_name: "bash".to_string(),
@@ -46,7 +51,12 @@ fn compose_quality_followup_maps_required_parameter_signal() {
     let input = ResponseTurnInput {
         run_id: RunId("run-1".to_string()),
         trusted_user_message: "where do i live".to_string(),
+        delivery_context: test_delivery_context(
+            sieve_types::DeliveryChannel::Stdin,
+            InteractionModality::Text,
+        ),
         response_modality: InteractionModality::Text,
+        resolved_personality: test_resolved_personality(),
         planner_thoughts: None,
         tool_outcomes: vec![ResponseToolOutcome {
             tool_name: "lcm_expand_query".to_string(),
@@ -77,7 +87,12 @@ fn compose_quality_followup_maps_denied_tool_signal() {
     let input = ResponseTurnInput {
         run_id: RunId("run-1".to_string()),
         trusted_user_message: "weather tomorrow".to_string(),
+        delivery_context: test_delivery_context(
+            sieve_types::DeliveryChannel::Stdin,
+            InteractionModality::Text,
+        ),
         response_modality: InteractionModality::Text,
+        resolved_personality: test_resolved_personality(),
         planner_thoughts: None,
         tool_outcomes: vec![ResponseToolOutcome {
             tool_name: "bash".to_string(),
@@ -100,7 +115,12 @@ fn compose_quality_followup_maps_conflict_signal() {
     let input = ResponseTurnInput {
         run_id: RunId("run-1".to_string()),
         trusted_user_message: "compare claims".to_string(),
+        delivery_context: test_delivery_context(
+            sieve_types::DeliveryChannel::Stdin,
+            InteractionModality::Text,
+        ),
         response_modality: InteractionModality::Text,
+        resolved_personality: test_resolved_personality(),
         planner_thoughts: None,
         tool_outcomes: vec![ResponseToolOutcome {
             tool_name: "bash".to_string(),
@@ -130,7 +150,12 @@ fn compose_quality_followup_maps_primary_content_fetch_signal() {
     let input = ResponseTurnInput {
         run_id: RunId("run-1".to_string()),
         trusted_user_message: "latest status".to_string(),
+        delivery_context: test_delivery_context(
+            sieve_types::DeliveryChannel::Stdin,
+            InteractionModality::Text,
+        ),
         response_modality: InteractionModality::Text,
+        resolved_personality: test_resolved_personality(),
         planner_thoughts: None,
         tool_outcomes: vec![ResponseToolOutcome {
             tool_name: "bash".to_string(),
@@ -162,7 +187,12 @@ fn compose_quality_followup_maps_url_extraction_signal() {
     let input = ResponseTurnInput {
         run_id: RunId("run-1".to_string()),
         trusted_user_message: "summarize".to_string(),
+        delivery_context: test_delivery_context(
+            sieve_types::DeliveryChannel::Stdin,
+            InteractionModality::Text,
+        ),
         response_modality: InteractionModality::Text,
+        resolved_personality: test_resolved_personality(),
         planner_thoughts: None,
         tool_outcomes: vec![ResponseToolOutcome {
             tool_name: "bash".to_string(),

--- a/crates/sieve-app/src/tests/compose_gate.rs
+++ b/crates/sieve-app/src/tests/compose_gate.rs
@@ -32,7 +32,12 @@ fn denied_outcomes_only_message_reports_attempt_and_reason() {
     let input = ResponseTurnInput {
         run_id: RunId("run-1".to_string()),
         trusted_user_message: "weather".to_string(),
+        delivery_context: test_delivery_context(
+            sieve_types::DeliveryChannel::Stdin,
+            InteractionModality::Text,
+        ),
         response_modality: InteractionModality::Text,
+        resolved_personality: test_resolved_personality(),
         planner_thoughts: None,
         tool_outcomes: vec![ResponseToolOutcome {
             tool_name: "bash".to_string(),

--- a/crates/sieve-app/src/tests/models.rs
+++ b/crates/sieve-app/src/tests/models.rs
@@ -356,6 +356,55 @@ impl ResponseModel for QueuedResponseModel {
     }
 }
 
+pub(crate) struct RecordingResponseModel {
+    config: LlmModelConfig,
+    output: sieve_llm::ResponseTurnOutput,
+    last_input: StdMutex<Option<ResponseTurnInput>>,
+}
+
+impl RecordingResponseModel {
+    pub(crate) fn new(message: &str) -> Self {
+        Self {
+            config: LlmModelConfig {
+                provider: LlmProvider::OpenAi,
+                model: "response-recording-test".to_string(),
+                api_base: None,
+            },
+            output: sieve_llm::ResponseTurnOutput {
+                message: message.to_string(),
+                referenced_ref_ids: BTreeSet::new(),
+                summarized_ref_ids: BTreeSet::new(),
+            },
+            last_input: StdMutex::new(None),
+        }
+    }
+
+    pub(crate) fn last_input(&self) -> Option<ResponseTurnInput> {
+        self.last_input
+            .lock()
+            .expect("recording response mutex poisoned")
+            .clone()
+    }
+}
+
+#[async_trait]
+impl ResponseModel for RecordingResponseModel {
+    fn config(&self) -> &LlmModelConfig {
+        &self.config
+    }
+
+    async fn write_turn_response(
+        &self,
+        input: ResponseTurnInput,
+    ) -> Result<sieve_llm::ResponseTurnOutput, LlmError> {
+        self.last_input
+            .lock()
+            .expect("recording response mutex poisoned")
+            .replace(input);
+        Ok(self.output.clone())
+    }
+}
+
 pub(crate) struct FirstStdoutSummaryResponseModel {
     config: LlmModelConfig,
 }

--- a/crates/sieve-app/src/tests/personality.rs
+++ b/crates/sieve-app/src/tests/personality.rs
@@ -1,0 +1,266 @@
+use super::*;
+
+fn temp_sieve_home(name: &str) -> PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "sieve-app-personality-{name}-{}-{}",
+        std::process::id(),
+        now_ms()
+    ));
+    fs::create_dir_all(&path).expect("create temp sieve home");
+    path
+}
+
+#[test]
+fn resolve_turn_personality_applies_telegram_defaults() {
+    let sieve_home = temp_sieve_home("telegram-defaults");
+    let resolution = resolve_turn_personality(
+        &sieve_home,
+        PromptSource::Telegram,
+        Some("42"),
+        InteractionModality::Text,
+        InteractionModality::Text,
+        "hi there",
+    )
+    .expect("resolve personality");
+
+    assert_eq!(
+        resolution.delivery_context.channel,
+        sieve_types::DeliveryChannel::Telegram
+    );
+    assert_eq!(
+        resolution.delivery_context.destination.as_deref(),
+        Some("42")
+    );
+    assert_eq!(
+        resolution.resolved_personality.emoji_policy,
+        sieve_types::EmojiPolicy::Light
+    );
+    assert_eq!(
+        resolution.resolved_personality.verbosity,
+        sieve_types::ResponseVerbosity::Concise
+    );
+    assert!(
+        resolution
+            .resolved_personality
+            .channel_guidance
+            .iter()
+            .any(|line| line.contains("Telegram")),
+        "telegram channel guidance should be present"
+    );
+
+    let _ = fs::remove_dir_all(sieve_home);
+}
+
+#[test]
+fn resolve_turn_personality_persists_and_reuses_style_updates() {
+    let sieve_home = temp_sieve_home("persist");
+    let first = resolve_turn_personality(
+        &sieve_home,
+        PromptSource::Stdin,
+        None,
+        InteractionModality::Text,
+        InteractionModality::Text,
+        "please don't use emojis",
+    )
+    .expect("resolve personality");
+    assert_eq!(
+        first.acknowledgement.as_deref(),
+        Some("I'll skip emojis from now on.")
+    );
+    assert_eq!(
+        first.resolved_personality.emoji_policy,
+        sieve_types::EmojiPolicy::Avoid
+    );
+    assert!(personality_state_path(&sieve_home).exists());
+
+    let second = resolve_turn_personality(
+        &sieve_home,
+        PromptSource::Telegram,
+        Some("42"),
+        InteractionModality::Text,
+        InteractionModality::Text,
+        "hi again",
+    )
+    .expect("resolve personality");
+    assert!(second.acknowledgement.is_none());
+    assert_eq!(
+        second.resolved_personality.emoji_policy,
+        sieve_types::EmojiPolicy::Avoid
+    );
+
+    let _ = fs::remove_dir_all(sieve_home);
+}
+
+#[test]
+fn resolve_turn_personality_keeps_turn_scoped_overrides_ephemeral() {
+    let sieve_home = temp_sieve_home("ephemeral");
+    let first = resolve_turn_personality(
+        &sieve_home,
+        PromptSource::Stdin,
+        None,
+        InteractionModality::Text,
+        InteractionModality::Text,
+        "for this reply, speak more tersely to conserve tokens: pretend we are communicating over telegraph",
+    )
+    .expect("resolve personality");
+    assert_eq!(
+        first.acknowledgement.as_deref(),
+        Some("For this reply, I'll use terse, telegraph-style phrasing.")
+    );
+    assert_eq!(
+        first.resolved_personality.verbosity,
+        sieve_types::ResponseVerbosity::Telegraph
+    );
+    assert!(
+        !personality_state_path(&sieve_home).exists(),
+        "turn-scoped override should not persist"
+    );
+
+    let second = resolve_turn_personality(
+        &sieve_home,
+        PromptSource::Stdin,
+        None,
+        InteractionModality::Text,
+        InteractionModality::Text,
+        "hello",
+    )
+    .expect("resolve personality");
+    assert_eq!(
+        second.resolved_personality.verbosity,
+        sieve_types::ResponseVerbosity::Concise
+    );
+
+    let _ = fs::remove_dir_all(sieve_home);
+}
+
+#[test]
+fn resolve_turn_personality_allows_expressive_persona_requests() {
+    let sieve_home = temp_sieve_home("expressive-persona");
+    let resolution = resolve_turn_personality(
+        &sieve_home,
+        PromptSource::Telegram,
+        Some("42"),
+        InteractionModality::Text,
+        InteractionModality::Text,
+        "I want you to start using a lot of emojis (2+ per message) and start acting like a valley girl",
+    )
+    .expect("resolve personality");
+
+    assert_eq!(
+        resolution.acknowledgement.as_deref(),
+        Some(
+            "I'll lean into emojis, use an emoji-heavy chat style with multiple emojis in text replies, and adopt a valley girl persona from now on."
+        )
+    );
+    assert_eq!(
+        resolution.resolved_personality.emoji_policy,
+        sieve_types::EmojiPolicy::Auto
+    );
+    assert!(
+        resolution
+            .resolved_personality
+            .custom_instructions
+            .iter()
+            .any(|line| line.contains("emoji-heavy")),
+        "emoji-heavy instruction should be preserved"
+    );
+    assert!(
+        resolution
+            .resolved_personality
+            .custom_instructions
+            .iter()
+            .any(|line| line.contains("valley girl persona")),
+        "persona instruction should be preserved"
+    );
+    assert!(personality_state_path(&sieve_home).exists());
+
+    let _ = fs::remove_dir_all(sieve_home);
+}
+
+#[tokio::test]
+async fn e2e_response_model_receives_delivery_context_and_personality() {
+    let planner: Arc<dyn PlannerModel> =
+        Arc::new(QueuedPlannerModel::new(vec![Ok(PlannerTurnOutput {
+            thoughts: Some("chat only".to_string()),
+            tool_calls: Vec::new(),
+        })]));
+    let guidance: Arc<dyn GuidanceModel> = Arc::new(QueuedGuidanceModel::new(vec![Ok(
+        guidance_output(PlannerGuidanceSignal::FinalAnswerReady),
+    )]));
+    let response_impl = Arc::new(RecordingResponseModel::new("Hello there."));
+    let response: Arc<dyn ResponseModel> = response_impl.clone();
+    let summary: Arc<dyn SummaryModel> = Arc::new(EchoSummaryModel);
+    let harness = AppE2eHarness::new(
+        E2eModelMode::Fake {
+            planner,
+            guidance,
+            response,
+            summary,
+        },
+        vec!["bash".to_string()],
+        E2E_POLICY_BASE,
+    );
+
+    harness
+        .run_telegram_text_turn("Hi how are you?")
+        .await
+        .expect("telegram turn should succeed");
+
+    let input = response_impl
+        .last_input()
+        .expect("response model should record input");
+    assert_eq!(
+        input.delivery_context.channel,
+        sieve_types::DeliveryChannel::Telegram
+    );
+    assert_eq!(input.delivery_context.destination.as_deref(), Some("42"));
+    assert_eq!(input.response_modality, InteractionModality::Text);
+    assert_eq!(
+        input.resolved_personality.emoji_policy,
+        sieve_types::EmojiPolicy::Light
+    );
+    assert!(
+        input
+            .resolved_personality
+            .channel_guidance
+            .iter()
+            .any(|line| line.contains("Telegram")),
+        "telegram guidance should reach response model"
+    );
+}
+
+#[tokio::test]
+async fn e2e_style_only_persona_request_is_acknowledged_not_refused() {
+    let planner: Arc<dyn PlannerModel> =
+        Arc::new(QueuedPlannerModel::new(vec![Ok(PlannerTurnOutput {
+            thoughts: Some("should not run".to_string()),
+            tool_calls: Vec::new(),
+        })]));
+    let guidance: Arc<dyn GuidanceModel> = Arc::new(QueuedGuidanceModel::new(vec![Ok(
+        guidance_output(PlannerGuidanceSignal::FinalAnswerReady),
+    )]));
+    let response: Arc<dyn ResponseModel> = Arc::new(RecordingResponseModel::new("unused"));
+    let summary: Arc<dyn SummaryModel> = Arc::new(EchoSummaryModel);
+    let harness = AppE2eHarness::new(
+        E2eModelMode::Fake {
+            planner,
+            guidance,
+            response,
+            summary,
+        },
+        vec!["bash".to_string()],
+        E2E_POLICY_BASE,
+    );
+
+    let flow = harness
+        .run_telegram_text_turn(
+            "I want you to start using a lot of emojis (2+ per message) and start acting like a valley girl",
+        )
+        .await
+        .expect("telegram turn should succeed");
+    let message = latest_telegram_message(&flow).expect("telegram message should be sent");
+    assert_eq!(
+        message,
+        "I'll lean into emojis, use an emoji-heavy chat style with multiple emojis in text replies, and adopt a valley girl persona from now on."
+    );
+}

--- a/crates/sieve-app/src/tests/render_response.rs
+++ b/crates/sieve-app/src/tests/render_response.rs
@@ -31,8 +31,16 @@ fn build_response_turn_input_handles_zero_tool_turn() {
         tool_results: Vec::new(),
     };
 
-    let (input, refs) =
-        build_response_turn_input(&run_id, "hi", InteractionModality::Text, &planner_result);
+    let (input, refs) = build_response_turn_input(
+        &run_id,
+        "hi",
+        test_delivery_context(
+            sieve_types::DeliveryChannel::Stdin,
+            InteractionModality::Text,
+        ),
+        test_resolved_personality(),
+        &planner_result,
+    );
     assert_eq!(input.run_id, run_id);
     assert_eq!(input.trusted_user_message, "hi");
     assert_eq!(input.response_modality, InteractionModality::Text);
@@ -46,7 +54,12 @@ fn requires_output_visibility_detects_non_empty_stdout_or_stderr_refs() {
     let input = ResponseTurnInput {
         run_id: RunId("run-1".to_string()),
         trusted_user_message: "show output".to_string(),
+        delivery_context: test_delivery_context(
+            sieve_types::DeliveryChannel::Stdin,
+            InteractionModality::Text,
+        ),
         response_modality: InteractionModality::Text,
+        resolved_personality: test_resolved_personality(),
         planner_thoughts: None,
         tool_outcomes: vec![ResponseToolOutcome {
             tool_name: "bash".to_string(),
@@ -78,7 +91,12 @@ fn requires_output_visibility_skips_when_user_did_not_ask_for_output() {
     let input = ResponseTurnInput {
             run_id: RunId("run-1".to_string()),
             trusted_user_message: "What is the weather tomorrow in Livermore?".to_string(),
+            delivery_context: test_delivery_context(
+                sieve_types::DeliveryChannel::Stdin,
+                InteractionModality::Text,
+            ),
             response_modality: InteractionModality::Text,
+            resolved_personality: test_resolved_personality(),
             planner_thoughts: None,
             tool_outcomes: vec![ResponseToolOutcome {
                 tool_name: "bash".to_string(),
@@ -105,7 +123,12 @@ fn response_has_visible_selected_output_requires_message_token() {
     let input = ResponseTurnInput {
         run_id: RunId("run-1".to_string()),
         trusted_user_message: "show output".to_string(),
+        delivery_context: test_delivery_context(
+            sieve_types::DeliveryChannel::Stdin,
+            InteractionModality::Text,
+        ),
         response_modality: InteractionModality::Text,
+        resolved_personality: test_resolved_personality(),
         planner_thoughts: None,
         tool_outcomes: vec![ResponseToolOutcome {
             tool_name: "bash".to_string(),
@@ -141,7 +164,12 @@ fn response_has_visible_selected_output_accepts_summary_token() {
     let input = ResponseTurnInput {
         run_id: RunId("run-1".to_string()),
         trusted_user_message: "summarize output".to_string(),
+        delivery_context: test_delivery_context(
+            sieve_types::DeliveryChannel::Stdin,
+            InteractionModality::Text,
+        ),
         response_modality: InteractionModality::Text,
+        resolved_personality: test_resolved_personality(),
         planner_thoughts: None,
         tool_outcomes: vec![ResponseToolOutcome {
             tool_name: "bash".to_string(),

--- a/crates/sieve-app/src/tests/response_style.rs
+++ b/crates/sieve-app/src/tests/response_style.rs
@@ -100,10 +100,31 @@ fn source_and_detail_request_detection() {
 #[test]
 fn concise_style_diagnostic_flags_unsolicited_source_dump() {
     let message = "Answer first. https://a.example https://b.example";
-    let diagnostic = concise_style_diagnostic(message, "What is the answer?");
+    let diagnostic = concise_style_diagnostic(
+        message,
+        "What is the answer?",
+        sieve_types::ResponseVerbosity::Concise,
+    );
     assert!(diagnostic.is_some());
-    let detail_ok = concise_style_diagnostic(message, "Give sources and links");
+    let detail_ok = concise_style_diagnostic(
+        message,
+        "Give sources and links",
+        sieve_types::ResponseVerbosity::Concise,
+    );
     assert!(detail_ok.is_none());
+}
+
+#[test]
+fn concise_style_diagnostic_respects_detailed_and_telegraph_profiles() {
+    let long = "Sentence one. Sentence two. Sentence three. Sentence four. Sentence five.";
+    assert!(
+        concise_style_diagnostic(long, "answer me", sieve_types::ResponseVerbosity::Detailed,)
+            .is_none()
+    );
+    assert!(
+        concise_style_diagnostic(long, "answer me", sieve_types::ResponseVerbosity::Telegraph,)
+            .is_some()
+    );
 }
 
 #[test]

--- a/crates/sieve-app/src/tests/runtime_bridge.rs
+++ b/crates/sieve-app/src/tests/runtime_bridge.rs
@@ -55,6 +55,7 @@ async fn runtime_bridge_submit_prompt_enqueues_telegram_input() {
 
     let prompt = rx.recv().await.expect("expected prompt");
     assert_eq!(prompt.source, PromptSource::Telegram);
+    assert_eq!(prompt.destination.as_deref(), Some("42"));
     assert_eq!(prompt.text, "check logs");
     assert_eq!(prompt.modality, InteractionModality::Text);
     assert!(prompt.media_file_id.is_none());

--- a/crates/sieve-app/src/tests/support.rs
+++ b/crates/sieve-app/src/tests/support.rs
@@ -1,4 +1,31 @@
 use super::*;
+
+pub(crate) fn test_delivery_context(
+    channel: sieve_types::DeliveryChannel,
+    response_modality: InteractionModality,
+) -> sieve_types::DeliveryContext {
+    sieve_types::DeliveryContext {
+        channel,
+        destination: match channel {
+            sieve_types::DeliveryChannel::Telegram => Some("42".to_string()),
+            sieve_types::DeliveryChannel::Stdin => None,
+        },
+        input_modality: InteractionModality::Text,
+        response_modality,
+    }
+}
+
+pub(crate) fn test_resolved_personality() -> sieve_types::ResolvedPersonality {
+    sieve_types::ResolvedPersonality {
+        identity: "helpful assistant".to_string(),
+        style: "clear and concise".to_string(),
+        emoji_policy: sieve_types::EmojiPolicy::Avoid,
+        verbosity: sieve_types::ResponseVerbosity::Concise,
+        channel_guidance: vec!["Use plain text.".to_string()],
+        custom_instructions: Vec::new(),
+    }
+}
+
 #[derive(Clone, Default)]
 struct SharedTelegramPoller {
     updates: Arc<StdMutex<VecDeque<Vec<TestTelegramUpdate>>>>,
@@ -223,6 +250,7 @@ impl AppE2eHarness {
             &self.cfg,
             run_index,
             PromptSource::Stdin,
+            None,
             InteractionModality::Text,
             None,
             prompt.to_string(),
@@ -309,6 +337,7 @@ impl AppE2eHarness {
             &self.cfg,
             run_index,
             PromptSource::Telegram,
+            ingress.destination,
             ingress.modality,
             ingress.media_file_id,
             ingress.text,

--- a/crates/sieve-app/src/turn/execute.rs
+++ b/crates/sieve-app/src/turn/execute.rs
@@ -7,6 +7,7 @@ use crate::ingress::PromptSource;
 use crate::lcm_integration::LcmIntegration;
 use crate::logging::{now_ms, ConversationLogRecord, ConversationRole, FanoutRuntimeEventLog};
 use crate::media;
+use crate::personality::resolve_turn_personality;
 use sieve_llm::{GuidanceModel, ResponseModel, SummaryModel};
 use sieve_runtime::{RuntimeEventLog, RuntimeOrchestrator};
 use sieve_types::{
@@ -24,6 +25,7 @@ pub(crate) async fn run_turn(
     cfg: &AppConfig,
     run_index: u64,
     source: PromptSource,
+    destination: Option<String>,
     input_modality: InteractionModality,
     media_file_id: Option<String>,
     user_message: String,
@@ -69,23 +71,38 @@ pub(crate) async fn run_turn(
         ))
         .await?;
 
-    let assistant_message = generate_assistant_message(
-        runtime,
-        guidance_model,
-        response_model,
-        summary_model,
-        event_log,
-        cfg,
-        &run_id,
-        &trusted_user_message,
+    let personality_resolution = resolve_turn_personality(
+        &cfg.sieve_home,
+        source,
+        destination.as_deref(),
+        input_modality,
         modality_contract.response,
-    )
-    .await?;
+        &trusted_user_message,
+    )?;
+    let assistant_message = match personality_resolution.acknowledgement {
+        Some(message) => message,
+        None => {
+            generate_assistant_message(
+                runtime,
+                guidance_model,
+                response_model,
+                summary_model,
+                event_log,
+                cfg,
+                &run_id,
+                &trusted_user_message,
+                &personality_resolution.delivery_context,
+                &personality_resolution.resolved_personality,
+            )
+            .await?
+        }
+    };
     println!("{}: {}", run_id.0, assistant_message);
 
     let delivered_audio = deliver_audio_reply_if_requested(
         cfg,
         source,
+        destination.as_deref(),
         &run_id,
         &assistant_message,
         &mut modality_contract,
@@ -123,6 +140,7 @@ pub(crate) async fn run_turn(
 async fn deliver_audio_reply_if_requested(
     cfg: &AppConfig,
     source: PromptSource,
+    destination: Option<&str>,
     run_id: &RunId,
     assistant_message: &str,
     modality_contract: &mut sieve_types::ModalityContract,
@@ -134,12 +152,11 @@ async fn deliver_audio_reply_if_requested(
 
     match media::synthesize_audio_reply(cfg, run_id, assistant_message).await {
         Ok(audio_path) => {
-            if let Err(err) = media::send_telegram_voice(
-                &cfg.telegram_bot_token,
-                cfg.telegram_chat_id,
-                &audio_path,
-            )
-            .await
+            let chat_id = destination
+                .and_then(|value| value.parse::<i64>().ok())
+                .unwrap_or(cfg.telegram_chat_id);
+            if let Err(err) =
+                media::send_telegram_voice(&cfg.telegram_bot_token, chat_id, &audio_path).await
             {
                 eprintln!("audio reply delivery failed for {}: {}", run_id.0, err);
                 override_modality_contract(

--- a/crates/sieve-app/src/turn/planner_loop.rs
+++ b/crates/sieve-app/src/turn/planner_loop.rs
@@ -20,8 +20,8 @@ use sieve_runtime::{
     EventLogError, PlannerRunRequest, PlannerRunResult, RuntimeEventLog, RuntimeOrchestrator,
 };
 use sieve_types::{
-    AssistantMessageEvent, InteractionModality, PlannerGuidanceFrame, PlannerGuidanceInput,
-    PlannerGuidanceSignal, RunId, RuntimeEvent,
+    AssistantMessageEvent, DeliveryContext, PlannerGuidanceFrame, PlannerGuidanceInput,
+    PlannerGuidanceSignal, ResolvedPersonality, RunId, RuntimeEvent,
 };
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -57,7 +57,8 @@ pub(super) async fn generate_assistant_message(
     cfg: &AppConfig,
     run_id: &RunId,
     trusted_user_message: &str,
-    response_modality: InteractionModality,
+    delivery_context: &DeliveryContext,
+    resolved_personality: &ResolvedPersonality,
 ) -> Result<String, Box<dyn std::error::Error>> {
     let mut aggregated_result = PlannerRunResult {
         thoughts: None,
@@ -268,7 +269,8 @@ pub(super) async fn generate_assistant_message(
         let (response_input, render_refs) = build_response_turn_input(
             run_id,
             trusted_user_message,
-            response_modality,
+            delivery_context.clone(),
+            resolved_personality.clone(),
             &aggregated_result,
         );
         let mut response_input = response_input;

--- a/crates/sieve-app/src/turn/response_refs.rs
+++ b/crates/sieve-app/src/turn/response_refs.rs
@@ -4,7 +4,7 @@ use sieve_llm::{
     ResponseRefMetadata, ResponseToolOutcome, ResponseTurnInput, SummaryModel, SummaryRequest,
 };
 use sieve_runtime::{PlannerRunResult, PlannerToolResult, RuntimeDisposition};
-use sieve_types::{Integrity, InteractionModality, RunId};
+use sieve_types::{DeliveryContext, Integrity, ResolvedPersonality, RunId};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
@@ -26,7 +26,8 @@ pub(crate) fn planner_allowed_tools_for_turn(
 pub(crate) fn build_response_turn_input(
     run_id: &RunId,
     trusted_user_message: &str,
-    response_modality: InteractionModality,
+    delivery_context: DeliveryContext,
+    resolved_personality: ResolvedPersonality,
     planner_result: &PlannerRunResult,
 ) -> (ResponseTurnInput, BTreeMap<String, RenderRef>) {
     let mut render_refs = BTreeMap::new();
@@ -39,7 +40,9 @@ pub(crate) fn build_response_turn_input(
         ResponseTurnInput {
             run_id: run_id.clone(),
             trusted_user_message: trusted_user_message.to_string(),
-            response_modality,
+            response_modality: delivery_context.response_modality,
+            delivery_context,
+            resolved_personality,
             planner_thoughts: planner_result.thoughts.clone(),
             tool_outcomes,
         },

--- a/crates/sieve-llm/src/lib.rs
+++ b/crates/sieve-llm/src/lib.rs
@@ -2,8 +2,8 @@
 
 use async_trait::async_trait;
 use sieve_types::{
-    InteractionModality, LlmModelConfig, PlannerGuidanceInput, PlannerGuidanceOutput,
-    PlannerTurnInput, PlannerTurnOutput, RunId,
+    DeliveryContext, InteractionModality, LlmModelConfig, PlannerGuidanceInput,
+    PlannerGuidanceOutput, PlannerTurnInput, PlannerTurnOutput, ResolvedPersonality, RunId,
 };
 use std::collections::BTreeSet;
 use thiserror::Error;
@@ -76,7 +76,9 @@ pub struct ResponseToolOutcome {
 pub struct ResponseTurnInput {
     pub run_id: RunId,
     pub trusted_user_message: String,
+    pub delivery_context: DeliveryContext,
     pub response_modality: InteractionModality,
+    pub resolved_personality: ResolvedPersonality,
     pub planner_thoughts: Option<String>,
     pub tool_outcomes: Vec<ResponseToolOutcome>,
 }

--- a/crates/sieve-llm/src/openai/requests.rs
+++ b/crates/sieve-llm/src/openai/requests.rs
@@ -15,7 +15,15 @@ Rules:
 - Prefer concrete, evidence-backed facts over generic link-only wording.
 - Answer the user request directly in the first sentence.
 - Keep responses concise by default: target 1-2 sentences unless the user explicitly asks for detailed output.
+- Follow `resolved_personality` as the style contract for this turn.
+- Respect `delivery_context.channel` and `delivery_context.response_modality`.
 - If `response_modality` is `audio`, write for speech delivery: natural spoken phrasing, no placeholder link talk, minimal parenthetical clutter.
+- If `resolved_personality.emoji_policy` is `avoid`, use no emojis.
+- If `resolved_personality.emoji_policy` is `auto`, follow channel norms plus any explicit emoji direction in `resolved_personality.custom_instructions`.
+- If `resolved_personality.emoji_policy` is `light`, use at most one light emoji when natural and only for chat-like text responses.
+- If `resolved_personality.verbosity` is `telegraph`, prefer terse, clipped phrasing.
+- If `resolved_personality.verbosity` is `detailed`, it is acceptable to be somewhat more detailed than the default.
+- Apply `resolved_personality.channel_guidance` and `resolved_personality.custom_instructions` unless they conflict with other rules.
 - If exact values are unavailable in evidence, state that explicitly and give the best available signal without guessing.
 - Include URLs only when the user asked for sources/links or when a URL is required for the immediate next step.
 - If uncertainty is necessary, include at most one short caveat sentence.

--- a/crates/sieve-llm/src/tests.rs
+++ b/crates/sieve-llm/src/tests.rs
@@ -7,8 +7,9 @@ use crate::wire::{
 use crate::{GuidanceModel, LlmError, OpenAiGuidanceModel, OpenAiPlannerModel, PlannerModel};
 use serde_json::json;
 use sieve_types::{
-    Action, Capability, LlmModelConfig, LlmProvider, PlannerTurnInput, PolicyDecision,
-    PolicyDecisionKind, PolicyEvaluatedEvent, Resource, RunId, RuntimeEvent,
+    Action, Capability, DeliveryChannel, DeliveryContext, EmojiPolicy, LlmModelConfig, LlmProvider,
+    PlannerTurnInput, PolicyDecision, PolicyDecisionKind, PolicyEvaluatedEvent,
+    ResolvedPersonality, Resource, ResponseVerbosity, RunId, RuntimeEvent,
     TOOL_CONTRACTS_VERSION_V1,
 };
 use std::collections::BTreeMap;
@@ -223,7 +224,21 @@ fn response_turn_round_trip_uses_safe_shape() {
     let payload = serialize_response_input(&crate::ResponseTurnInput {
         run_id: RunId("run-resp".to_string()),
         trusted_user_message: "hi".to_string(),
+        delivery_context: DeliveryContext {
+            channel: DeliveryChannel::Telegram,
+            destination: Some("42".to_string()),
+            input_modality: sieve_types::InteractionModality::Text,
+            response_modality: sieve_types::InteractionModality::Audio,
+        },
         response_modality: sieve_types::InteractionModality::Audio,
+        resolved_personality: ResolvedPersonality {
+            identity: "helpful assistant".to_string(),
+            style: "clear and concise".to_string(),
+            emoji_policy: EmojiPolicy::Avoid,
+            verbosity: ResponseVerbosity::Telegraph,
+            channel_guidance: vec!["Write for Telegram.".to_string()],
+            custom_instructions: vec!["Skip filler.".to_string()],
+        },
         planner_thoughts: Some("none".to_string()),
         tool_outcomes: vec![crate::ResponseToolOutcome {
             tool_name: "bash".to_string(),
@@ -242,6 +257,8 @@ fn response_turn_round_trip_uses_safe_shape() {
     assert!(payload.get("tool_outcomes").is_some());
     assert!(payload.to_string().contains("trusted_user_message"));
     assert!(payload.to_string().contains("response_modality"));
+    assert!(payload.to_string().contains("delivery_context"));
+    assert!(payload.to_string().contains("resolved_personality"));
     assert!(payload.to_string().contains("attempted_command"));
 
     let out = decode_response_output(json!({

--- a/crates/sieve-llm/src/wire/response.rs
+++ b/crates/sieve-llm/src/wire/response.rs
@@ -9,7 +9,15 @@ Rules:
 - Produce a concise, user-facing response for this turn.
 - Answer the user request directly in the first sentence.
 - Keep default output short (1-2 sentences) unless the user explicitly asks for detailed output.
+- Follow `resolved_personality` as the style contract for this turn.
+- Respect `delivery_context.channel` and `delivery_context.response_modality`.
 - If `response_modality` is `audio`, write for speech delivery: natural spoken phrasing, minimal punctuation clutter, no bullet lists unless necessary.
+- If `resolved_personality.emoji_policy` is `avoid`, do not use emojis.
+- If `resolved_personality.emoji_policy` is `auto`, follow channel norms plus any explicit emoji direction in `resolved_personality.custom_instructions`.
+- If `resolved_personality.emoji_policy` is `light`, use at most one light emoji when natural and only for chat-like turns.
+- If `resolved_personality.verbosity` is `telegraph`, prefer clipped, terse phrasing.
+- If `resolved_personality.verbosity` is `detailed`, it is acceptable to be somewhat more detailed than the default.
+- Apply `resolved_personality.channel_guidance` and `resolved_personality.custom_instructions` unless they conflict with other rules.
 - Use only provided structured fields; do not invent actions.
 - Avoid giant messages. Prefer short responses.
 - Write in first person as a helpful assistant; never use third-person/meta narration.
@@ -63,7 +71,9 @@ pub(crate) fn serialize_response_input(input: &ResponseTurnInput) -> Result<Valu
     Ok(json!({
         "run_id": input.run_id.0,
         "trusted_user_message": input.trusted_user_message,
+        "delivery_context": input.delivery_context,
         "response_modality": input.response_modality,
+        "resolved_personality": input.resolved_personality,
         "planner_thoughts": input.planner_thoughts,
         "tool_outcomes": tool_outcomes
     }))

--- a/crates/sieve-types/src/delivery.rs
+++ b/crates/sieve-types/src/delivery.rs
@@ -1,0 +1,19 @@
+use crate::InteractionModality;
+use serde::{Deserialize, Serialize};
+
+/// Outbound or inbound communication surface for a user turn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeliveryChannel {
+    Stdin,
+    Telegram,
+}
+
+/// Delivery metadata that should survive through response composition.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeliveryContext {
+    pub channel: DeliveryChannel,
+    pub destination: Option<String>,
+    pub input_modality: InteractionModality,
+    pub response_modality: InteractionModality,
+}

--- a/crates/sieve-types/src/lib.rs
+++ b/crates/sieve-types/src/lib.rs
@@ -3,11 +3,13 @@
 mod capabilities;
 mod commands;
 mod contract_freeze_v1;
+mod delivery;
 mod events;
 mod guidance;
 mod ids;
 mod llm;
 mod modality;
+mod personality;
 mod policy;
 #[cfg(test)]
 mod tests;
@@ -16,10 +18,12 @@ mod tools;
 pub use capabilities::*;
 pub use commands::*;
 pub use contract_freeze_v1::*;
+pub use delivery::*;
 pub use events::*;
 pub use guidance::*;
 pub use ids::*;
 pub use llm::*;
 pub use modality::*;
+pub use personality::*;
 pub use policy::*;
 pub use tools::*;

--- a/crates/sieve-types/src/personality.rs
+++ b/crates/sieve-types/src/personality.rs
@@ -1,0 +1,56 @@
+use serde::{Deserialize, Serialize};
+
+/// Emoji policy for user-facing responses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum EmojiPolicy {
+    #[default]
+    Auto,
+    Avoid,
+    Light,
+}
+
+/// Brevity contract for user-facing responses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ResponseVerbosity {
+    #[default]
+    Concise,
+    Detailed,
+    Telegraph,
+}
+
+/// Persisted or turn-scoped personality overrides.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct PersonalitySettings {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub emoji_policy: Option<EmojiPolicy>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verbosity: Option<ResponseVerbosity>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub custom_instructions: Vec<String>,
+}
+
+/// Final resolved personality contract for a response turn.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedPersonality {
+    pub identity: String,
+    pub style: String,
+    pub emoji_policy: EmojiPolicy,
+    pub verbosity: ResponseVerbosity,
+    pub channel_guidance: Vec<String>,
+    pub custom_instructions: Vec<String>,
+}
+
+impl Default for ResolvedPersonality {
+    fn default() -> Self {
+        Self {
+            identity: "helpful, optimistic, cheerful personal assistant".to_string(),
+            style: "clear and concise".to_string(),
+            emoji_policy: EmojiPolicy::Auto,
+            verbosity: ResponseVerbosity::Concise,
+            channel_guidance: Vec::new(),
+            custom_instructions: Vec::new(),
+        }
+    }
+}

--- a/crates/sieve-types/src/tests.rs
+++ b/crates/sieve-types/src/tests.rs
@@ -134,6 +134,36 @@ fn assistant_message_event_json_round_trip() {
 }
 
 #[test]
+fn delivery_context_json_round_trip() {
+    let context = DeliveryContext {
+        channel: DeliveryChannel::Telegram,
+        destination: Some("42".to_string()),
+        input_modality: InteractionModality::Text,
+        response_modality: InteractionModality::Audio,
+    };
+
+    let encoded = serde_json::to_string(&context).expect("serialize");
+    let decoded: DeliveryContext = serde_json::from_str(&encoded).expect("deserialize");
+    assert_eq!(decoded, context);
+}
+
+#[test]
+fn resolved_personality_json_round_trip() {
+    let personality = ResolvedPersonality {
+        identity: "helpful assistant".to_string(),
+        style: "clear and concise".to_string(),
+        emoji_policy: EmojiPolicy::Light,
+        verbosity: ResponseVerbosity::Telegraph,
+        channel_guidance: vec!["Keep replies short for chat.".to_string()],
+        custom_instructions: vec!["Skip filler.".to_string()],
+    };
+
+    let encoded = serde_json::to_string(&personality).expect("serialize");
+    let decoded: ResolvedPersonality = serde_json::from_str(&encoded).expect("deserialize");
+    assert_eq!(decoded, personality);
+}
+
+#[test]
 fn endorse_payload_json_round_trip() {
     let request = EndorseRequest {
         value_ref: ValueRef("v123".into()),

--- a/docs/personality-layering.md
+++ b/docs/personality-layering.md
@@ -1,0 +1,24 @@
+---
+summary: "How Sieve resolves user-facing reply personality across channels and persisted preferences"
+read_when:
+  - You are modifying reply composition or delivery context.
+  - You are debugging why the assistant changed tone, emoji usage, or verbosity.
+title: "Personality Layering"
+---
+
+# Personality Layering
+
+Sieve now resolves user-facing personality as layered runtime state instead of a single hard-coded prompt string.
+
+The active reply personality is resolved in this order.
+
+1. Base default assistant identity: helpful, optimistic, cheerful, clear, and concise.
+2. Channel defaults from delivery context, such as `telegram` chat guidance versus `stdin` plain-text guidance.
+3. Persisted user preferences from `SIEVE_HOME/state/personality.json`.
+4. Turn-scoped overrides inferred from the current trusted user message.
+
+Current built-in override detection supports common requests such as disabling emojis, requesting lighter or emoji-heavy chat style, asking for more detail, requesting terse or telegraph-like replies, and tone/persona shifts like more formal, more flirty, or “act like a valley girl.”
+
+If a user message is only a personality instruction, Sieve acknowledges the change directly and skips planner execution for that turn.
+
+The resolved personality and delivery context are injected into both the response writer and the compose pass so channel-aware style survives through the final user-facing message.


### PR DESCRIPTION
## Current context
- This branch snapshots the current personality-layering attempt.
- It threads `DeliveryContext` and `ResolvedPersonality` through reply generation and compose.
- It adds persisted personality state at `SIEVE_HOME/state/personality.json`.
- It uses parser-driven override detection for emoji/tone/verbosity/persona requests, plus direct acknowledgement for style-only requests.
- It adds tests and docs for the current approach.
- Verification already run on this snapshot: `cargo fmt --all`, `cargo test -p sieve-types`, `cargo test -p sieve-llm`, `cargo test -p sieve-app`, `cargo build --release -p sieve-app`.
- User feedback: this direction is wrong because it hardcodes too much of personality modification behavior.

## User message (exact)
```text
ok so this is all wrong wrt the hardcoding. what it needs to be is:
- model has instructions indicating it can modify personality
- one line telling it to read skill to learn how to modify personality
```
